### PR TITLE
Use pyreadline on Windows

### DIFF
--- a/compoundpi/__init__.py
+++ b/compoundpi/__init__.py
@@ -58,6 +58,9 @@ if sys.version_info[:2] == (3, 2):
         'MarkupSafe<0.16',
         ])
 
+if sys.platform.startswith('Win'):
+    __requires__.append('pyreadline')
+
 __classifiers__ = [
     'Development Status :: 4 - Beta',
     'Environment :: Console',

--- a/compoundpi/cmdline.py
+++ b/compoundpi/cmdline.py
@@ -50,11 +50,15 @@ base class. The extra facilities provided are:
 import os
 import re
 import cmd
-import readline
 import locale
 import logging
 import warnings
 from textwrap import TextWrapper
+
+try:
+  import readline
+except ImportError:
+  import pyreadline as readline
 
 from .terminal import _CONSOLE
 


### PR DESCRIPTION
readline is not supported on Windows, [pyreadline](https://pypi.org/project/pyreadline/) is a Python-only alternative. With this fix, the CLI can run on Windows.